### PR TITLE
Alice's encoding result corrected

### DIFF
--- a/content/ch-algorithms/quantum-key-distribution.ipynb
+++ b/content/ch-algorithms/quantum-key-distribution.ipynb
@@ -1974,7 +1974,7 @@
     "\n",
     "次にアリスは、各ビットを自分が選んだ基底を使って量子ビット列上にエンコードします。そうすると、各量子ビットは、ランダムに選ばれた $|0\\rangle$, $|1\\rangle$, $|+\\rangle$, $|-\\rangle$ のいずれかの状態になります。この場合、量子ビット列は次のようになるでしょう：\n",
     "\n",
-    "$$ |-\\rangle|0\\rangle|+\\rangle|0\\rangle|1\\rangle|0\\rangle|1\\rangle|+\\rangle|1\\rangle|-\\rangle|+\\rangle|-\\rangle|0\\rangle|-\\rangle|0\\rangle|+\\rangle\n",
+    "$$ |1\\rangle|0\\rangle|+\\rangle|0\\rangle|-\\rangle|+\\rangle|-\\rangle|0\\rangle|-\\rangle|1\\rangle|+\\rangle|-\\rangle|+\\rangle|-\\rangle|+\\rangle|+\\rangle\n",
     "$$\n",
     "\n",
     "これが、彼女がボブに送るメッセージになります。\n",


### PR DESCRIPTION
3.12 Fixed Alice's encoding result
# Changes made
Qubits string typo in Step2 in 'Protocol Overview' corrected

# Justification
Synchronized with the correction of original English version